### PR TITLE
Make spider compatible with Python 3.5.

### DIFF
--- a/spider.py
+++ b/spider.py
@@ -13,7 +13,7 @@ def scrap_member (url):
     member_page = requests.get(url)
     member_soup = BeautifulSoup(member_page.content, "html.parser", from_encoding="windows-1250")
     member = {
-        "id": re.search("id=(.*)", url)[1],
+        "id": re.search("id=(.*)", url).group(1),
         "name": replace_nbsp(member_soup.h1.string),
         "assistants": [],
     }


### PR DESCRIPTION
This fixes #3 for Python 3.5. Works well also with Python 3.6.

![giphy](https://user-images.githubusercontent.com/193936/38989885-8ee093e2-43d8-11e8-98f7-4ac2a00fa4fc.gif)
